### PR TITLE
[PLAYGROUND] Custom components with rehype-react

### DIFF
--- a/content/concepts/introduction.md
+++ b/content/concepts/introduction.md
@@ -22,6 +22,19 @@ makeArray() {
 }
 ```
 
+---
+
+<!-- By default it seems like Remark will wrap custom components like this here in a <p> tag
+    This limits the usage of the markup within the components, as it's not allowed to have
+    other tags as <span> etc. as child nodes.
+    Only solution I could found is to wrap the custom component in its own HTML tag like here: -->
+<section>
+    <callout-box color="red" title="This is a test callout box">
+        Hey there! That was easy to implement! Let's see what else is possible.
+        What about MDX for example?
+    </callout-box>
+</section>
+
 ### This is the third heading
 
 Pork chop ribeye ut chicken buffalo proident minim leberkas cupim adipisicing burgdoggen incididunt pastrami cupidatat. Prosciutto kevin dolore labore ham, cupidatat pork loin fatback picanha irure ad short ribs duis. Cupidatat excepteur jerky doner, incididunt consectetur turkey pariatur. Culpa consectetur cillum shank ham hock anim pastrami ex tempor eu. Fatback strip steak pig, bacon salami drumstick ut capicola short loin flank.

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "prismjs": "^1.15.0",
     "react": "16.5.1",
     "react-dom": "16.5.1",
-    "react-helmet": "^5.2.0"
+    "react-helmet": "^5.2.0",
+    "rehype-react": "^3.0.3"
   }
 }

--- a/src/components/callout.js
+++ b/src/components/callout.js
@@ -1,0 +1,22 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+const Callout = (props) => {
+    const color = props.color
+    const title = props.title
+    const text = props.children
+    return (
+        <div className={color}>
+            <h1>{title}</h1>
+            <p>{text}</p>
+        </div>
+    )
+}
+
+Callout.propTypes = {
+    color: PropTypes.string.isRequired,
+    title: PropTypes.string.isOptional,
+    children: PropTypes.node.isRequired,
+}
+
+export default Callout

--- a/src/templates/doc.js
+++ b/src/templates/doc.js
@@ -1,8 +1,15 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { graphql } from 'gatsby'
+import rehypeReact from 'rehype-react'
 
 import Layout from '../components/layouts/default'
+import Callout from '../components/callout'
+
+const renderAst = new rehypeReact({
+    createElement: React.createElement,
+    components: { "callout-box": Callout },
+}).Compiler
 
 const DocTemplate = ({ data }) => {
     const post = data.markdownRemark
@@ -14,7 +21,11 @@ const DocTemplate = ({ data }) => {
 
                     <div className="post-full-content">
                         <h1 className="title">{post.frontmatter.title}</h1>
-                        <section className="post-wrapper" dangerouslySetInnerHTML={{ __html: post.html }} />
+                        <section className="post-wrapper">
+                            {
+                                renderAst(post.htmlAst)
+                            }
+                        </section>
                     </div>
 
                 </main>
@@ -36,7 +47,7 @@ export const articleQuery = graphql`
             frontmatter {
                 title
             }
-            html
+            htmlAst
         }
     }
 `

--- a/yarn.lock
+++ b/yarn.lock
@@ -2846,6 +2846,15 @@ css-what@2.1:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.0.tgz#9467d032c38cfaefb9f2d79501253062f87fa1bd"
 
+css@2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/css/-/css-2.2.4.tgz#c646755c73971f2bba6a601e2cf2fd71b1298929"
+  dependencies:
+    inherits "^2.0.3"
+    source-map "^0.6.1"
+    source-map-resolve "^0.5.2"
+    urix "^0.1.0"
+
 cssesc@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-0.1.0.tgz#c814903e45623371a0477b40109aaafbeeaddbb4"
@@ -4983,6 +4992,17 @@ hast-to-hyperscript@^3.0.0:
     space-separated-tokens "^1.0.0"
     trim "0.0.1"
     unist-util-is "^2.0.0"
+
+hast-to-hyperscript@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/hast-to-hyperscript/-/hast-to-hyperscript-5.0.0.tgz#5106cbba78edb7c95e2e8a49079371eb196c1ced"
+  dependencies:
+    comma-separated-tokens "^1.0.0"
+    property-information "^4.0.0"
+    space-separated-tokens "^1.0.0"
+    style-to-object "^0.2.1"
+    unist-util-is "^2.0.0"
+    web-namespaces "^1.1.2"
 
 hast-util-from-parse5@^2.0.0:
   version "2.1.0"
@@ -7840,6 +7860,12 @@ property-information@^3.0.0, property-information@^3.1.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/property-information/-/property-information-3.2.0.tgz#fd1483c8fbac61808f5fe359e7693a1f48a58331"
 
+property-information@^4.0.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/property-information/-/property-information-4.2.0.tgz#f0e66e07cbd6fed31d96844d958d153ad3eb486e"
+  dependencies:
+    xtend "^4.0.1"
+
 proto-list@~1.2.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/proto-list/-/proto-list-1.2.4.tgz#212d5bfe1318306a420f6402b8e26ff39647a849"
@@ -8249,6 +8275,13 @@ regjsparser@^0.3.0:
   resolved "https://registry.yarnpkg.com/regjsparser/-/regjsparser-0.3.0.tgz#3c326da7fcfd69fa0d332575a41c8c0cdf588c96"
   dependencies:
     jsesc "~0.5.0"
+
+rehype-react@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/rehype-react/-/rehype-react-3.0.3.tgz#868af1b6b454927af8052501910c3cdc531a2b37"
+  dependencies:
+    has "^1.0.1"
+    hast-to-hyperscript "^5.0.0"
 
 relay-compiler@1.5.0:
   version "1.5.0"
@@ -8967,7 +9000,7 @@ source-list-map@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.0.tgz#aaa47403f7b245a92fbc97ea08f250d6087ed085"
 
-source-map-resolve@^0.5.0:
+source-map-resolve@^0.5.0, source-map-resolve@^0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.2.tgz#72e2cc34095543e43b2c62b2c4c10d4a9054f259"
   dependencies:
@@ -9238,6 +9271,12 @@ style-loader@^0.21.0:
   dependencies:
     loader-utils "^1.1.0"
     schema-utils "^0.4.5"
+
+style-to-object@^0.2.1:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/style-to-object/-/style-to-object-0.2.2.tgz#3ea3b276bd3fa9da1195fcdcdd03bc52aa2aae01"
+  dependencies:
+    css "2.2.4"
 
 stylehacks@^4.0.0:
   version "4.0.0"
@@ -9952,7 +9991,7 @@ wbuf@^1.1.0, wbuf@^1.7.2:
   dependencies:
     minimalistic-assert "^1.0.0"
 
-web-namespaces@^1.0.0:
+web-namespaces@^1.0.0, web-namespaces@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/web-namespaces/-/web-namespaces-1.1.2.tgz#c8dc267ab639505276bae19e129dbd6ae72b22b4"
 


### PR DESCRIPTION
This is a test of how custom components with rehype-react could work.

There are some limitations, but the implementation is fairly simple.

Result: http://localhost:8000/concepts/introduction/

More notes on this here: https://using-remark.gatsbyjs.org/custom-components/

I will submit a second PR which uses MDX files allow the usage of custom components. Once submitted, we can decide, which solution fits better for our purposes.