### PR TITLE
Helpers demo

### DIFF
--- a/src/templates/faq.js
+++ b/src/templates/faq.js
@@ -5,7 +5,7 @@ import Link from 'gatsby-link'
 
 import Layout from '../components/layouts/default'
 import { Spirit } from '../components/spirit-styles'
-import Tags from '../components/helpers/tags'
+import Tags from '@tryghost/react-helpers/tags'
 import GhostMetaData from '../components/layouts/partials/ghost-head'
 
 class FAQ extends React.Component {
@@ -30,7 +30,8 @@ class FAQ extends React.Component {
                                 <Tags
                                     post={post}
                                     separator=" / "
-                                    html={true}
+                                    classes="darkgrey fw5"
+                                    separatorClasses="mr1 ml1 f8 midgrey"
                                 />
                             </div>
 


### PR DESCRIPTION
# Tag Helper Demo Notes:

There are a few repos affected by this demo:

- Ghost-SDK: https://github.com/TryGhost/Ghost-SDK/tree/helpers-demo
- Ghost: https://github.com/ErisDS/Ghost/tree/helpers-demo
- Docs (this PR)

## Ghost-SDK

In Ghost-SDK we have two new packages: helpers and react-helpers.

Inside of the new helpers package, are 2 things:

1. Our visibility filter and parsing utils from Ghost - they belong here
2. A new vanilla JS tags helper

Inside of the new react-helpers package is a new generic `<Tags />` component

## Ghost

Inside of Ghost there will be 2 changes:

1. No more weird visibility utils on the model
2. Our handlebars `{{tags}}` helper now depends on `@tryghost/helpers/tags`

Note: I haven't moved the handlebars helpers to the Ghost-SDKs repo today because this is a much bigger, more complex refactor and it is not needed to unblock the docs project.

## Docs

Inside this PR, I've done 2 commits. 

The first showed how the built-in tags helper could depend directly on `@tryghost/helpers/tags`

The second, replaces our existing usage with the generic `@tryghost/react-helpers/tags` component.

Note: there were errors in master when I pulled before the flight - the faq template isn't actually used. I didn't commit the fix because I assumed that would be done whilst I was on the plane.

The new react component has mostly the same options as our existing handlebars helper + the ability to specify classes.

I also introduced a "fallback" option, so its possible to pass a tag either to the new react helper or the vanilla helper, and that gets used if no tags are left after filtering.

I removed the `internal` boolean from the original helper. If set to true this would include internal tags as well as public ones. With handlebars / Ghost / the preexisting helper we didn't have this, we had a `visibility` property which would be set to `public` by default, but you could set it to `public, internal` or `internal`. This gives absolute flexibility and future proofs against their being other visibility values for tags e.g. private (members only) tags.

I also removed the concept of not rendering HTML from this helper. IMO the react helper is for outputting React, if you don't want that, then you can fall back to using the vanilla helper, that will already output strings for you.

Naming Q: should it be react-helpers or helpers-react? 
- React helpers is easier when cd'ing
- I think both read OK
- Putting helpers first means they'll sit next to each other in Ghost-SDK/packages folder
