### PR TITLE
Use gatsby-image for local img

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -6,6 +6,7 @@ const cssNano = require(`cssnano`)
 const customProperties = require(`postcss-custom-properties`)
 const easyImport = require(`postcss-easy-import`)
 const algoliaQueries = require(`./src/utils/algolia-queries`)
+const path = require(`path`)
 
 require(`dotenv`).config({
     path: `.env.${process.env.NODE_ENV}`,
@@ -21,7 +22,7 @@ module.exports = {
     siteMetadata: {
         title: `Ghost Docs`,
         siteUrl: process.env.SITE_URL || `https://docs.ghost.org`,
-        description: `Everything you need to know about working with the Ghost professional publishing platform.`
+        description: `Everything you need to know about working with the Ghost professional publishing platform.`,
     },
     plugins: [
         /**
@@ -30,9 +31,16 @@ module.exports = {
         {
             resolve: `gatsby-source-filesystem`,
             options: {
-                path: `${__dirname}/content/`,
-                name: `markdown-pages`
-            }
+                path: path.join(__dirname, `content`),
+                name: `markdown-pages`,
+            },
+        },
+        {
+            resolve: `gatsby-source-filesystem`,
+            options: {
+                name: `images`,
+                path: path.join(__dirname, `src`, `images`),
+            },
         },
         {
             resolve: `gatsby-transformer-remark`,
@@ -41,26 +49,26 @@ module.exports = {
                     {
                         resolve: `gatsby-remark-images`,
                         options: {
-                            maxWidth: 590
-                        }
+                            maxWidth: 590,
+                        },
                     },
                     `gatsby-remark-code-titles`,
                     `gatsby-remark-prismjs`, // TODO: make aliases work!
                     `gatsby-remark-external-links`,
-                    `gatsby-remark-autolink-headers`
-                ]
-            }
+                    `gatsby-remark-autolink-headers`,
+                ],
+            },
         },
-        `gatsby-transformer-sharp`,
         `gatsby-plugin-sharp`,
+        `gatsby-transformer-sharp`,
         `gatsby-transformer-yaml`,
         {
             resolve: `gatsby-source-ghost`,
             options: {
                 apiUrl: `https://docs-2.ghost.io`,
                 clientId: `ghost-frontend`,
-                clientSecret: `${process.env.GH_CLIENT_SECRET}`
-            }
+                clientSecret: `${process.env.GH_CLIENT_SECRET}`,
+            },
         },
         {
             resolve: `gatsby-plugin-algolia`,
@@ -68,8 +76,8 @@ module.exports = {
                 appId: `6RCFK5TOI5`,
                 apiKey: `${process.env.ALGOLIA_ADMIN_KEY}`,
                 queries: algoliaQueries,
-                chunkSize: 10000 // default: 1000
-            }
+                chunkSize: 10000, // default: 1000
+            },
         },
         `gatsby-plugin-catch-links`,
         /**
@@ -84,8 +92,8 @@ module.exports = {
                 background_color: `#343f44`,
                 theme_color: `#343f44`,
                 display: `minimal-ui`,
-                icon: `src/images/favicon.png`
-            }
+                icon: `src/images/favicon.png`,
+            },
         },
         `gatsby-plugin-offline`,
         `gatsby-plugin-react-helmet`,
@@ -104,17 +112,17 @@ module.exports = {
                     colorModFunction(),
                     customProperties({ preserve: false }),
                     postcssCustomMedia(),
-                    cssNano({ zindex: false })
-                ]
-            }
+                    cssNano({ zindex: false }),
+                ],
+            },
         },
         {
             resolve: `gatsby-plugin-react-svg`,
             options: {
                 rule: {
-                    include: /icons/
-                }
-            }
-        }
-    ]
-};
+                    include: /icons/,
+                },
+            },
+        },
+    ],
+}

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "algolia-html-extractor": "^0.0.1",
     "bluebird": "3.5.2",
     "gatsby": "2.0.24",
+    "gatsby-image": "^2.0.15",
     "gatsby-plugin-algolia": "^0.2.0",
     "gatsby-plugin-catch-links": "^2.0.5",
     "gatsby-plugin-force-trailing-slashes": "^1.0.4",

--- a/src/templates/integration.js
+++ b/src/templates/integration.js
@@ -3,9 +3,10 @@ import PropTypes from 'prop-types'
 import Link from 'gatsby-link'
 import { graphql } from 'gatsby'
 import Prism from 'prismjs'
+import Img from "gatsby-image"
 
 import Layout from '../components/layouts/default'
-import integrationIcon from '../images/integration-icon.png'
+// import integrationIcon from '../images/integration-icon.png'
 import { Spirit } from '../components/spirit-styles'
 import TOC from '../components/layouts/partials/toc'
 import MetaData from '../components/layouts/partials/meta-data'
@@ -35,7 +36,7 @@ class Integration extends React.Component {
                                 <img className="mw100" src={post.feature_image} alt={post.title} />
                             </div>
                             <div className="flex-shrink-0 flex justify-center items-center h30 w30 pa11 bg-white br-100 shadow-3 nl2 nr2">
-                                <img className="mw100" src={integrationIcon} alt="Ghost" />
+                                <Img className="mw100" fixed={this.props.data.file.childImageSharp.fixed} alt="Ghost" />
                             </div>
                         </div>
                     </div>
@@ -74,6 +75,13 @@ export const articleQuery = graphql`
         }
         ghostPost(slug: { eq: $slug }) {
             ...GhostPostFields
+        }
+        file(relativePath: {eq: "integration-icon.png"}) {
+            childImageSharp {
+                fixed(width: 32, height: 32) {
+                    ...GatsbyImageSharpFixed
+                }
+            }
         }
     }
 `

--- a/yarn.lock
+++ b/yarn.lock
@@ -722,6 +722,10 @@
     react-lifecycles-compat "^3.0.4"
     warning "^3.0.0"
 
+"@sheerun/mutationobserver-shim@^0.3.2":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.2.tgz#8013f2af54a2b7d735f71560ff360d3a8176a87b"
+
 "@sinonjs/commons@^1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.0.2.tgz#3e0ac737781627b8844257fadc3d803997d0526e"
@@ -1141,7 +1145,7 @@ ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
 
-ansi-styles@^3.2.1:
+ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
   dependencies:
@@ -3668,6 +3672,14 @@ dom-serializer@0, dom-serializer@~0.1.0:
     domelementtype "~1.1.1"
     entities "~1.1.1"
 
+dom-testing-library@^3.1.0:
+  version "3.11.0"
+  resolved "https://registry.yarnpkg.com/dom-testing-library/-/dom-testing-library-3.11.0.tgz#374fbc1f4b61405ac10a27cb3a6d3912c3ed1dd3"
+  dependencies:
+    "@sheerun/mutationobserver-shim" "^0.3.2"
+    pretty-format "^23.6.0"
+    wait-for-expect "^1.0.0"
+
 dom-walk@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/dom-walk/-/dom-walk-0.1.1.tgz#672226dc74c8f799ad35307df936aba11acd6018"
@@ -4996,6 +5008,14 @@ gatsby-cli@^2.4.3:
     update-notifier "^2.3.0"
     yargs "^11.1.0"
     yurnalist "^0.2.1"
+
+gatsby-image@^2.0.15:
+  version "2.0.15"
+  resolved "https://registry.yarnpkg.com/gatsby-image/-/gatsby-image-2.0.15.tgz#16dec0f7ed2f8ec19d3de53931ea539054583dbb"
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    prop-types "^15.6.1"
+    react-testing-library "^4.1.7"
 
 gatsby-link@^2.0.4:
   version "2.0.4"
@@ -9372,6 +9392,13 @@ pretty-error@^2.1.1:
     renderkid "^2.0.1"
     utila "~0.4"
 
+pretty-format@^23.6.0:
+  version "23.6.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-23.6.0.tgz#5eaac8eeb6b33b987b7fe6097ea6a8a146ab5760"
+  dependencies:
+    ansi-regex "^3.0.0"
+    ansi-styles "^3.2.0"
+
 prettyjson@^1.1.3:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/prettyjson/-/prettyjson-1.2.1.tgz#fcffab41d19cab4dfae5e575e64246619b12d289"
@@ -9704,6 +9731,13 @@ react-side-effect@^1.1.0:
   dependencies:
     exenv "^1.2.1"
     shallowequal "^1.0.1"
+
+react-testing-library@^4.1.7:
+  version "4.1.9"
+  resolved "https://registry.yarnpkg.com/react-testing-library/-/react-testing-library-4.1.9.tgz#a96fe41fd2a6205d6a2029604f46df18b9cda2d2"
+  dependencies:
+    dom-testing-library "^3.1.0"
+    wait-for-expect "^1.0.0"
 
 react-themeable@^1.1.0:
   version "1.1.0"
@@ -12057,6 +12091,10 @@ w3c-hr-time@^1.0.1:
   resolved "https://registry.yarnpkg.com/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz#82ac2bff63d950ea9e3189a58a65625fedf19045"
   dependencies:
     browser-process-hrtime "^0.1.2"
+
+wait-for-expect@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/wait-for-expect/-/wait-for-expect-1.0.1.tgz#73ab346ed56ed2ef66c380a59fd623755ceac0ce"
 
 ware@^1.2.0:
   version "1.3.0"


### PR DESCRIPTION
Had a play with `gatsby-image`
Only one image currently that we're referring to locally (Markdown does not work yet, still needs to be converted to MDX) -> the Ghost logo on any integrations article.
