### PR TITLE
Added cloning command for Ghost-Admin

### DIFF
--- a/content/install/source.md
+++ b/content/install/source.md
@@ -69,8 +69,8 @@ git remote add origin git@github.com:<YourUsername>/Ghost.git
 Because Ghost-Admin is a submodule repository of the main Ghost repository, the same steps need to be repeated to configure Git here, too.
 
 ```bash
-# Switch to Ghost-Admin dir
-cd core/client
+# Switch to Ghost-Admin dir and clone it. Don't forget the '.' at the end
+cd core/client && git clone git@github.com:TryGhost/Ghost-Admin.git .
 ```
 
 #### Properly rename your references again


### PR DESCRIPTION
Hello,
I may be misunderstanding something here, but in the way I see how git works, we're still in the Ghost git project in the core/client dir, whereas we need to do changes on the Ghost-Admin project. A new project must be initialized - or Ghost-Admin must be cloned - in here so changes for the remotes will be made for this specific dir and not for the Ghost one

I tried the two solutions, mine works whereas I have issues with yours (pulling Ghost-Admin directly)

As it is my first PR, I'd be pleased if you tell me if I'm doing something wrong or if I'm missing something
Have a nice programming time