### PR TITLE
Fix Integrations > Facebook overflow issue

### DIFF
--- a/src/templates/integration.js
+++ b/src/templates/integration.js
@@ -58,7 +58,7 @@ class Integration extends React.Component {
                                     }
                                 </div>
                             </div>
-                            <article className="w-100 order-1 pr15-ns">
+                            <article className="miw1 w-100 order-1 pr15-ns">
                                 <div className="mb0 f8">
                                     <Link className="link midlightgrey fw5" to="/integrations/">Integrations</Link>
                                     <span className="mr1 ml1 f8 midgrey">/</span>


### PR DESCRIPTION
## Summary
Add a minimum width to the article container to force reset on flex item widths. Previously mentioned here: https://github.com/TryGhost/docs/pull/34#issuecomment-436731936
![screen shot 2018-11-07 at 23 09 17](https://user-images.githubusercontent.com/1177460/48167083-7cdacb00-e2e2-11e8-8eaa-88cee7316560.png)
