### PR TITLE
Fix odd text alignment for integration on index page

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -125,25 +125,25 @@ class IndexPage extends React.Component {
                                 All your favourite apps and tools, integrated with Ghost. <Link to="/integrations/" className="blue link din nb1 mt2 mt0-ns hover-underline-blue"><span className="flex items-center fw5">Browse all integrations <Icon name="arrow-right" className="w3 h3 ml1 fill-blue" /></span></Link>
                             </p>
                             <div className="grid-integrations-index mt4 mt6-l f8">
-                                <Box to="/integrations/zapier/" className="br4 flex flex-column justify-between items-center middarkgrey pa2 pt5 pb5 tdn" onWhite="false" elevation="2">
+                                <Box to="/integrations/zapier/" className="br4 flex flex-column justify-between items-center middarkgrey pa2 pt5 pb5 tdn tc" onWhite="false" elevation="2">
                                     <img className="w10 mb1" src="https://res.cloudinary.com/tryghost/image/fetch/w_120,h_100,c_fit/https://docs.ghost.io/content/images/2018/09/zapier.png" alt="Zapier" />
                                     Zapier</Box>
-                                <Box to="/integrations/disqus/" className="br4 flex flex-column justify-between items-center middarkgrey pa2 pt5 pb5 tdn" onWhite="false" elevation="2">
+                                <Box to="/integrations/disqus/" className="br4 flex flex-column justify-between items-center middarkgrey pa2 pt5 pb5 tdn tc" onWhite="false" elevation="2">
                                     <img className="w10 mb1" src="https://res.cloudinary.com/tryghost/image/fetch/w_120,h_100,c_fit/https://docs.ghost.io/content/images/2018/09/disqus.svg" alt="Disqus" />
                                     Disqus</Box>
-                                <Box to="/integrations/slack/" className="br4 flex flex-column justify-between items-center middarkgrey pa2 pt5 pb5 tdn" onWhite="false" elevation="2">
+                                <Box to="/integrations/slack/" className="br4 flex flex-column justify-between items-center middarkgrey pa2 pt5 pb5 tdn tc" onWhite="false" elevation="2">
                                     <img className="w10 mb1" src="https://res.cloudinary.com/tryghost/image/fetch/w_120,h_100,c_fit/https://docs.ghost.io/content/images/2018/09/slack.png" alt="Slack" />
                                     Slack</Box>
-                                <Box to="/integrations/unsplash/" className="br4 flex flex-column justify-between items-center middarkgrey pa2 pt5 pb5 tdn" onWhite="false" elevation="2">
+                                <Box to="/integrations/unsplash/" className="br4 flex flex-column justify-between items-center middarkgrey pa2 pt5 pb5 tdn tc" onWhite="false" elevation="2">
                                     <img className="w10 mb1" src="https://res.cloudinary.com/tryghost/image/fetch/w_120,h_100,c_fit/https://docs.ghost.io/content/images/2018/09/unsplash.svg" alt="Unsplash" />
                                     Unsplash</Box>
-                                <Box to="/integrations/google-analytics/" className="br4 flex flex-column justify-between items-center middarkgrey pa2 pt5 pb5 tdn" onWhite="false" elevation="2">
+                                <Box to="/integrations/google-analytics/" className="br4 flex flex-column justify-between items-center middarkgrey pa2 pt5 pb5 tdn tc" onWhite="false" elevation="2">
                                     <img className="w10 mb1" src="https://res.cloudinary.com/tryghost/image/fetch/w_120,h_100,c_fit/https://docs.ghost.io/content/images/2018/09/google-analytics-1.png" alt="Google Analytics" />
                                     Google Analytics</Box>
-                                <Box to="/integrations/mailchimp/" className="br4 flex flex-column justify-between items-center middarkgrey pa2 pt5 pb5 tdn" onWhite="false" elevation="2">
+                                <Box to="/integrations/mailchimp/" className="br4 flex flex-column justify-between items-center middarkgrey pa2 pt5 pb5 tdn tc" onWhite="false" elevation="2">
                                     <img className="w10 mb1" src="https://res.cloudinary.com/tryghost/image/fetch/w_120,h_100,c_fit/https://docs.ghost.io/content/images/2018/09/mailchimp.png" alt="Mailchimp" />
                                     Mailchimp</Box>
-                                <Box to="/integrations/google-amp/" className="flex br4 flex-column justify-between items-center middarkgrey pa2 pt5 pb5 tdn" onWhite="false" elevation="2">
+                                <Box to="/integrations/google-amp/" className="flex br4 flex-column justify-between items-center middarkgrey pa2 pt5 pb5 tdn tc" onWhite="false" elevation="2">
                                     <img className="w10 mb1" src="https://res.cloudinary.com/tryghost/image/fetch/w_120,h_100,c_fit/https://docs.ghost.io/content/images/2018/09/amp.jpg" alt="Google AMP" />
                                     Google AMP</Box>
                                 <Box to="/integrations/" className="br4 flex flex-column justify-between items-center middarkgrey pa2 pt5 pb5 tdn" onWhite="false" elevation="2">


### PR DESCRIPTION
I fixed the odd text alignment as described in #37. It only happened on the index page since on the integrations page the items already had the `tc` class.

Before:

<img width="434" alt="48195448-95310100-e347-11e8-84d1-b53fac5610f8" src="https://user-images.githubusercontent.com/1591511/48364475-cf343700-e6a8-11e8-97b1-1282e84d674c.png">

Afterwards:
<img width="255" alt="screenshot 2018-11-12 at 18 29 12" src="https://user-images.githubusercontent.com/1591511/48364504-e07d4380-e6a8-11e8-8974-6a40ecc61938.png">

