### PR TITLE
Fix typos in routing.md

### DIFF
--- a/content/concepts/routing.md
+++ b/content/concepts/routing.md
@@ -213,7 +213,7 @@ Custom `rss` feeds can be set with the `content_type` property and a template.
 
 ### content_type
 
-Use this property this to specify a route returns something other than HTML. For example to create a custom RSS feed:
+Use this property to specify a route returns something other than HTML. For example to create a custom RSS feed:
 ```yaml
 routes:
   /podcast/rss/:
@@ -239,7 +239,7 @@ The trailing slash is required, so `/blog/:` is valid, but `/blog:` is not. The 
 * `example.com/blog/`
 * `example.com/blog/page/2`
 
-Ghost will use the default template to render these routes. For example, `index.hbs` for `/blog:/` and `home.hbs` for `/:` - unless specific templates are set using the [template](http://docs.ghost.org/concepts/routing/#template) property.
+Ghost will use the default template to render these routes. For example, `index.hbs` for `/blog/:` and `home.hbs` for `/:` - unless specific templates are set using the [template](http://docs.ghost.org/concepts/routing/#template) property.
 
 
 ### permalink


### PR DESCRIPTION
- remove duplicated "this"
- fix `/` position in `/blog:/`