### PR TITLE
'@blog' page no longer exists, changed to '@site'

### DIFF
--- a/src/data/sidebars/handlebars.yaml
+++ b/src/data/sidebars/handlebars.yaml
@@ -43,8 +43,8 @@
         link: /api/handlebars-themes/helpers/data/
       - title: '@config'
         link: /api/handlebars-themes/helpers/config/
-      - title: '@blog'
-        link: /api/handlebars-themes/helpers/blog/
+      - title: '@site'
+        link: /api/handlebars-themes/helpers/site/
       - title: navigation
         link: /api/handlebars-themes/helpers/navigation/
       - title: post


### PR DESCRIPTION
The sidebar in the handlebars docs was still displaying '@blog' and not '@site'. @blog was already changed at 'https://docs.ghost.org/api/handlebars-themes/helpers/data/', this will change the sidebar to match.