### PR TITLE
Makes gatsby files more readable and structured

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,14 +1,6 @@
 const onRouteUpdate = require(`./gatsby/onRouteUpdate`)
 const onPreRouteUpdate = require(`./gatsby/onPreRouteUpdate`)
 
-exports.onRouteUpdate = () => {
-    return {
-        trustAllScripts: onRouteUpdate(),
-    }
-}
+exports.onRouteUpdate = () => onRouteUpdate.trustAllScripts()
 
-exports.onPreRouteUpdate = () => {
-    return {
-        killServiceWorker: onPreRouteUpdate(),
-    }
-}
+exports.onPreRouteUpdate = () => onPreRouteUpdate.killServiceWorker()

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,2 +1,14 @@
-exports.onRouteUpdate = require(`./gatsby/onRouteUpdate`)
-exports.onPreRouteUpdate = require(`./gatsby/onPreRouteUpdate`)
+const onRouteUpdate = require(`./gatsby/onRouteUpdate`)
+const onPreRouteUpdate = require(`./gatsby/onPreRouteUpdate`)
+
+exports.onRouteUpdate = () => {
+    return {
+        trustAllScripts: onRouteUpdate(),
+    }
+}
+
+exports.onPreRouteUpdate = () => {
+    return {
+        killServiceWorker: onPreRouteUpdate(),
+    }
+}

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,4 +1,5 @@
 const createPages = require(`./gatsby/createPages`)
+const onCreateNode = require(`./gatsby/onCreateNode`)
 
 exports.createPages = ({ graphql, actions }) => {
     return {
@@ -8,4 +9,8 @@ exports.createPages = ({ graphql, actions }) => {
     }
 }
 
-exports.onCreateNode = require(`./gatsby/onCreateNode`)
+exports.onCreateNode = ({ node, getNode, actions }) => {
+    return {
+        createMarkdownNodeFields: onCreateNode.createMarkdownNodeFields(({ node, getNode, actions })),
+    }
+}

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,16 +1,13 @@
+const Promise = require(`bluebird`)
 const createPages = require(`./gatsby/createPages`)
 const onCreateNode = require(`./gatsby/onCreateNode`)
 
-exports.createPages = ({ graphql, actions }) => {
-    return {
-        createRedirects: createPages.createRedirects({ actions }),
-        createGhostPages: createPages.createGhostPages({ graphql, actions }),
-        createMarkdownPages: createPages.createMarkdownPages({ graphql, actions }),
-    }
-}
+exports.createPages = ({ graphql, actions }) => Promise.props({
+    createRedirects: createPages.createRedirects({ actions }),
+    createGhostPages: createPages.createGhostPages({ graphql, actions }),
+    createMarkdownPages: createPages.createMarkdownPages({ graphql, actions }),
+})
 
-exports.onCreateNode = ({ node, getNode, actions }) => {
-    return {
-        createMarkdownNodeFields: onCreateNode.createMarkdownNodeFields(({ node, getNode, actions })),
-    }
-}
+exports.onCreateNode = ({ node, getNode, actions }) => Promise.props({
+    createMarkdownNodeFields: onCreateNode.createMarkdownNodeFields(({ node, getNode, actions })),
+})

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,2 +1,11 @@
-exports.createPages = require(`./gatsby/createPages`)
+const createPages = require(`./gatsby/createPages`)
+
+exports.createPages = ({ graphql, actions }) => {
+    return {
+        createRedirects: createPages.createRedirects({ actions }),
+        createGhostPages: createPages.createGhostPages({ graphql, actions }),
+        createMarkdownPages: createPages.createMarkdownPages({ graphql, actions }),
+    }
+}
+
 exports.onCreateNode = require(`./gatsby/onCreateNode`)

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,13 +1,10 @@
-const Promise = require(`bluebird`)
 const createPages = require(`./gatsby/createPages`)
 const onCreateNode = require(`./gatsby/onCreateNode`)
 
-exports.createPages = ({ graphql, actions }) => Promise.props({
-    createRedirects: createPages.createRedirects({ actions }),
-    createGhostPages: createPages.createGhostPages({ graphql, actions }),
-    createMarkdownPages: createPages.createMarkdownPages({ graphql, actions }),
-})
+exports.createPages = ({ graphql, actions }) => Promise.all([
+    createPages.createRedirects({ actions }),
+    createPages.createGhostPages({ graphql, actions }),
+    createPages.createMarkdownPages({ graphql, actions }),
+])
 
-exports.onCreateNode = ({ node, getNode, actions }) => Promise.props({
-    createMarkdownNodeFields: onCreateNode.createMarkdownNodeFields(({ node, getNode, actions })),
-})
+exports.onCreateNode = async ({ node, getNode, actions }) => await onCreateNode.createMarkdownNodeFields(({ node, getNode, actions }))

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -1,1 +1,0 @@
-exports.onRenderBody = require(`./gatsby/onRenderBody`)

--- a/gatsby/createPages.js
+++ b/gatsby/createPages.js
@@ -6,10 +6,8 @@ const { ghostQueryConfig } = require(`../utils/query-config`)
 const urlUtils = require(`../utils/urls`)
 const getRelatedPosts = require(`../utils/getRelatedPosts`)
 
-module.exports = async ({ graphql, actions }) => {
-    const { createPage } = actions
+module.exports.createRedirects = ({ actions }) => {
     const { createRedirect } = actions
-    const queryPromises = []
 
     createRedirect({
         fromPath: `/api/admin/`,
@@ -25,6 +23,11 @@ module.exports = async ({ graphql, actions }) => {
         redirectInBrowser: true,
         toPath: `/concepts/introduction/`,
     })
+}
+
+module.exports.createGhostPages = async ({ graphql, actions }) => {
+    const { createPage } = actions
+    const queryPromises = []
 
     // Query for each of the tags that we defined above
     ghostQueryConfig.forEach(({ tag, section, template, tagsTemplate }) => {
@@ -99,6 +102,13 @@ module.exports = async ({ graphql, actions }) => {
                 })
         }))
     })
+
+    return Promise.all(queryPromises)
+}
+
+module.exports.createMarkdownPages = async ({ graphql, actions }) => {
+    const { createPage } = actions
+    const queryPromises = []
 
     queryPromises.push(new Promise((resolve, reject) => {
         graphql(allMarkdownPosts())

--- a/gatsby/createPages.js
+++ b/gatsby/createPages.js
@@ -1,4 +1,3 @@
-const Promise = require(`bluebird`)
 const path = require(`path`)
 const _ = require(`lodash`)
 const { allGhostPosts, allMarkdownPosts } = require(`../utils/node-queries`)

--- a/gatsby/onCreateNode.js
+++ b/gatsby/onCreateNode.js
@@ -4,7 +4,7 @@ const urlUtils = require(`../utils/urls`)
 const { markdownQueryConfig, defaultMarkdownSection } = require(`../utils/query-config`)
 const knownSections = _.map(markdownQueryConfig, `section`)
 
-module.exports = async ({ node, getNode, actions }) => {
+module.exports.createMarkdownNodeFields = async ({ node, getNode, actions }) => {
     const { createNodeField } = actions
 
     if (node.internal.type === `MarkdownRemark`) {

--- a/gatsby/onPreRouteUpdate.js
+++ b/gatsby/onPreRouteUpdate.js
@@ -7,15 +7,11 @@
  */
 const SERVICE_WORKER_KILL_SWITCH = (process.env.SERVICE_WORKER_KILL_SWITCH === `true`) || false
 
-const killServiceWorker = () => {
+module.exports.killServiceWorker = () => {
     if (SERVICE_WORKER_KILL_SWITCH && `serviceWorker` in navigator && /https/.test(location.protocol)) {
         navigator.serviceWorker.getRegistrations().then(registratons => registratons.forEach((registration) => {
             console.log(`Unregister service worker:`, registration)
             return registration.unregister()
         }))
     }
-}
-
-module.exports = function () {
-    killServiceWorker()
 }

--- a/gatsby/onPreRouteUpdate.js
+++ b/gatsby/onPreRouteUpdate.js
@@ -8,8 +8,7 @@
 const SERVICE_WORKER_KILL_SWITCH = (process.env.SERVICE_WORKER_KILL_SWITCH === `true`) || false
 
 const killServiceWorker = () => {
-    // && /https/.test(location.protocol)
-    if (SERVICE_WORKER_KILL_SWITCH && `serviceWorker` in navigator) {
+    if (SERVICE_WORKER_KILL_SWITCH && `serviceWorker` in navigator && /https/.test(location.protocol)) {
         navigator.serviceWorker.getRegistrations().then(registratons => registratons.forEach((registration) => {
             console.log(`Unregister service worker:`, registration)
             return registration.unregister()

--- a/gatsby/onRenderBody.js
+++ b/gatsby/onRenderBody.js
@@ -1,7 +1,0 @@
-const React = require(`react`)
-
-module.exports = ({ setPreBodyComponents }) => {
-    setPreBodyComponents([
-        <noscript key="noscript">Your browser does not support JavaScript!</noscript>,
-    ])
-}

--- a/gatsby/onRouteUpdate.js
+++ b/gatsby/onRouteUpdate.js
@@ -10,7 +10,7 @@
  *
  * TODO: use our browser eslint for this code
  */
-var trustAllScripts = function () {
+module.exports.trustAllScripts = function () {
     var scriptNodes = document.querySelectorAll('.external-scripts script');
 
     for (var i = 0; i < scriptNodes.length; i += 1) {
@@ -23,8 +23,4 @@ var trustAllScripts = function () {
             document.getElementsByTagName('head')[0].appendChild(s);
         }
     }
-};
-
-module.exports = function () {
-    trustAllScripts();
 };

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "@tryghost/helpers": "1.0.1",
     "@tryghost/helpers-gatsby": "1.0.1",
     "algolia-html-extractor": "0.0.1",
-    "bluebird": "3.5.3",
     "gatsby": "2.0.116",
     "gatsby-image": "2.0.29",
     "gatsby-plugin-algolia": "0.3.0",


### PR DESCRIPTION
closes #70

🚚 **Make `createPages` API methods more readable**
- Splits the functionality in gatsby/createPages.js into three different exported functions:
    1. createRedirects
    2. createGhostPages
    3. createMarkdownPages
- Return those three functions in form of `Promise.all()` in our `gatsby-node.js` file instead of simply requiring the whole file.
- This way we are able to see what's meant to happen within our `createPages` without the need to open the required files, as the methods are explaining the functionality themselves.

🚚 **Make `onCreateNode` API methods more readable**
- Name the fn in `onCreateNode.js` so it's more clear what it does → `createMarkdownNodeFields`
- Return these functions in form of an object in our `gatsby-node.js` file instead of simply requiring the whole file.

🚚 **Destructure gatsby-browser file to show fn names**
- Restructure `gatsby-browser.js` file to return the method names that we're using for each browser API endpoint so it's more clear to understand what each method does.

**Other improvements**
- ✅ Put back protocol check for killServiceWorker, which was only commented out for testing purposes 
- 🔥 Removed unneded noscript fallback, which is now incl. in Gatsby by default since https://github.com/gatsbyjs/gatsby/pull/10945 (v2.0.90)
- ⬇️ Removed Bluebird dependency as we're only using `Promise.all()` which is ES6 native