### PR TITLE
Swap {{lang}} -> {{@site.lang}}

### DIFF
--- a/src/data/sidebars/handlebars.yaml
+++ b/src/data/sidebars/handlebars.yaml
@@ -89,8 +89,6 @@
         link: /api/handlebars-themes/helpers/prev_next_post/
       - title: plural
         link: /api/handlebars-themes/helpers/plural/
-      - title: lang
-        link: /api/handlebars-themes/helpers/lang/
       - title: translate
         link: /api/handlebars-themes/helpers/translate/
       - title: encode

--- a/static/_redirects
+++ b/static/_redirects
@@ -24,6 +24,7 @@ https://newdocs.ghost.org/*      https://docs.ghost.org/:splat                  
 # CURRENT REDIRECTS
 /concepts                                   /concepts/introduction/                         301!
 /api/handlebars-themes/helpers/blog         /api/handlebars-themes/helpers/site             301!
+/api/handlebars-themes/helpers/lang         /api/handlebars-themes/helpers/site             301!
 /concepts/routing                           /api/handlebars-themes/routing/                 301!
 /concepts/redirects                         /api/handlebars-themes/redirects/               301!
 


### PR DESCRIPTION
Site language is a setting exposed via the `{{@site}}` object as `{{@site.lang}}`. When added, this was overlooked and an extra special helper was added that does the same thing.

We decided to deprecate the extra custom helper in favour of the simpler option. This updates the docs to do this. The property will be removed in 3.0.

- Removed documentation for deprecated special {{lang}} helper
- Added documentation for undocumented {{@site.lang}} property
- Added a redirect
- Updated all references and sidebars
