### PR TITLE
Admin API reference & Client Lib docs

### DIFF
--- a/gatsby/createPages.js
+++ b/gatsby/createPages.js
@@ -8,12 +8,6 @@ const getRelatedPosts = require(`../utils/getRelatedPosts`)
 module.exports.createRedirects = ({ actions }) => {
     const { createRedirect } = actions
 
-    createRedirect({
-        fromPath: `/api/admin/`,
-        isPermanent: true,
-        redirectInBrowser: true,
-        toPath: `https://api.ghost.org`,
-    })
     // The /concepts page doesn't exist, we need to redirect to
     // the first post of this section
     createRedirect({

--- a/src/data/sidebars/admin-api.yaml
+++ b/src/data/sidebars/admin-api.yaml
@@ -1,4 +1,27 @@
-- title: Admin API
-  items:
-    - title: Overview
-      link: /api/admin/
+- groups:
+  - group: Getting Started
+    items:
+      - title: Overview
+        link: /api/admin/
+      - title: Authentication
+        link: /api/admin/authentication/
+      - title: Concepts
+        link: /api/admin/concepts/
+  - group: Endpoints
+    items:
+      - title: Overview
+        link: /api/admin/endpoints/
+      - title: Posts
+        link: /api/admin/posts/
+      - title: Pages
+        link: /api/admin/pages/
+      - title: Tags
+        link: /api/admin/tags/
+      - title: Users
+        link: /api/admin/users/
+      - title: Images
+        link: /api/admin/images/
+  - group: Advanced
+    items:
+      - title: Publishing
+        link: /api/admin/publishing/

--- a/src/data/sidebars/admin-api.yaml
+++ b/src/data/sidebars/admin-api.yaml
@@ -12,15 +12,15 @@
       - title: Overview
         link: /api/admin/endpoints/
       - title: Posts
-        link: /api/admin/posts/
+        link: /api/admin/endpoints/#posts
       - title: Pages
-        link: /api/admin/pages/
+        link: /api/admin/endpoints/#pages
       - title: Tags
-        link: /api/admin/tags/
+        link: /api/admin/endpoints/#tags
       - title: Users
-        link: /api/admin/users/
+        link: /api/admin/endpoints/#users
       - title: Images
-        link: /api/admin/images/
+        link: /api/admin/endpoints/#images
   - group: Advanced
     items:
       - title: Publishing

--- a/src/data/sidebars/javascript.yaml
+++ b/src/data/sidebars/javascript.yaml
@@ -1,0 +1,13 @@
+- groups:
+  - group: Getting Started
+    items:
+      - title: Overview
+        link: /api/javascript/
+  - group: Content API
+    items:
+      - title: Content API
+        link: /api/javascript/#content-api
+  - group: Admin API
+    items:
+      - title: Admin API
+        link: /api/javascript/#admin-api

--- a/static/_redirects
+++ b/static/_redirects
@@ -28,11 +28,6 @@ https://newdocs.ghost.org/*      https://docs.ghost.org/:splat                  
 /concepts/routing                           /api/handlebars-themes/routing/                 301!
 /concepts/redirects                         /api/handlebars-themes/redirects/               301!
 
-# Temporary API redirects
-/api/admin                                  https://api.ghost.org/                          301!
-/api/admin/*                                https://api.ghost.org/                          301!
-
-
 # ---------------- OLD CONTENT - PROBABLY DONT EDIT BELOW HERE ----------------
 
 /docs/search                           /                                        301!


### PR DESCRIPTION
Drafting these in preparation for the release of the Admin API. 

API Reference: https://deploy-preview-90--tryghost.netlify.com/api/admin/
Client Library: https://deploy-preview-90--tryghost.netlify.com/api/javascript-admin/

These docs are rough stubs. The admin client library needs a home within the docs structure.