### PR TITLE
Minor install tweaks

### DIFF
--- a/content/install/local.md
+++ b/content/install/local.md
@@ -75,6 +75,8 @@ Ghost runs in a separate background process and remains running until you stop i
 * `ghost log` views logs
 * `ghost ls` to list all running Ghost blogs
 
+Run `ghost help` for a list of available commands, or explore the full [Ghost-CLI documentation](/api/ghost-cli/).
+
 #### Troubleshooting
 For troubleshooting and errors, try searching this documentation and [FAQ section](/faq/) to find information about common error messages.
 

--- a/content/install/ubuntu.md
+++ b/content/install/ubuntu.md
@@ -136,8 +136,8 @@ su - <user>
 You will need to have a [supported version](/faq/node-versions/) of Node installed system-wide in the manner described below. If you have a different setup, you may encounter problems.
 
 ```bash
-# Add the NodeSource APT repository for Node 8
-curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash
+# Add the NodeSource APT repository for Node 10
+curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash
 
 # Install Node.js
 sudo apt-get install -y nodejs


### PR DESCRIPTION
Made a couple of minor updates to our top-level install docs whilst looking at the command docs. 

1) I updated the ubuntu guide to specify Node.js v10 as that's what we recommend
2) I noticed there was no link to CLI reference on the local install guide, so I lifted the relevant sentence from the ubuntu guide and placed in in the command list section where I expected to see it as I was reading through.