### PR TITLE
Switch to use absolute URLs for Algolia search

### DIFF
--- a/src/components/common/search/Search.js
+++ b/src/components/common/search/Search.js
@@ -13,17 +13,46 @@ import Autosuggest from 'react-autosuggest'
 import { Spirit } from '../../../styles/spirit-styles'
 import { searchConfig } from '../../../../utils/query-config'
 
-const HitTemplate = ({ hit }) => (
-    <Link to={hit.url} className="tdn db pt3 pb3 blue search-result nl5 nr11 pl5 pr11 br3 br--left">
-        <h4 className={`${Spirit.h5} dib`}>
-            <Highlight attribute="title" hit={hit} tagName="mark" className="search-result-page blue" />
-        </h4>
-        <p className={`${Spirit.small} midgrey nudge-bottom--2`}>
-            <Snippet attribute="html" hit={hit} className="search-result-snippet" />
-            ...
-        </p>
-    </Link>
-)
+const HitTemplate = ({ hit }) => {
+    let hitOnCurrentSite = false
+
+    // The Algolia app now contains indexes from Docs as well as ghost.org.
+    // We therefore send absolute URLs now to Algolia, but need to strip them
+    // out again if the search result is on the current site, so we can determine
+    // if we use Gatsby Link or standard <a> tag.
+    // TODO: remove this again, once the move to G3 is fully completed
+    const siteUrl = `^${process.env.SITE_URL || `https://docs.ghost.org`}`
+    const siteUrlRegex = new RegExp(siteUrl)
+
+    if (hit.url.match(siteUrlRegex)) {
+        hit.url = hit.url.replace(siteUrlRegex, ``)
+        hitOnCurrentSite = true
+    }
+    return (
+        <>
+            {hitOnCurrentSite ?
+                <Link to={hit.url} className="tdn db pt3 pb3 blue search-result nl5 nr11 pl5 pr11 br3 br--left">
+                    <h4 className={`${Spirit.h5} dib`}>
+                        <Highlight attribute="title" hit={hit} tagName="mark" className="search-result-page blue" />
+                    </h4>
+                    <p className={`${Spirit.small} midgrey nudge-bottom--2`}>
+                        <Snippet attribute="html" hit={hit} className="search-result-snippet" />
+                ...
+                    </p>
+                </Link> :
+                <a href={hit.url} className="tdn db pt3 pb3 blue search-result nl5 nr11 pl5 pr11 br3 br--left">
+                    <h4 className={`${Spirit.h5} dib`}>
+                        <Highlight attribute="title" hit={hit} tagName="mark" className="search-result-page blue" />
+                    </h4>
+                    <p className={`${Spirit.small} midgrey nudge-bottom--2`}>
+                        <Snippet attribute="html" hit={hit} className="search-result-snippet" />
+                        ...
+                    </p>
+                </a>
+            }
+        </>
+    )
+}
 
 HitTemplate.propTypes = {
     hit: PropTypes.shape({

--- a/utils/algolia-queries.js
+++ b/utils/algolia-queries.js
@@ -34,7 +34,8 @@ const mdNodeMap = ({ node }) => {
     node.section = node.fields.section
     node.title = node.frontmatter.title
     // @TODO make this consistent?!
-    node.url = node.slug
+    // TODO: switch to relative URLs again, once the move to G3 is fully completed
+    node.url = urlUtils.convertToAbsoluteUrl(node.slug)
 
     delete node.frontmatter
     delete node.fields
@@ -51,7 +52,8 @@ const ghostQueries = ghostQueryConfig.map(({ tag, section, indexName }) => {
             .map(({ node }) => {
                 // @TODO is there some other way to do this?!
                 node.section = section
-                node.url = urlUtils.urlForGhostPost(node, section)
+                // TODO: switch to relative URLs again, once the move to G3 is fully completed
+                node.url = urlUtils.urlForGhostPost(node, section, true)
                 return node
             })
             .reduce(fragmentTransformer, []),


### PR DESCRIPTION
no issue

- in preparation of moving over and combining our search indexes and results from two different pages, we need to have absolute URLs send to Algolia, so we know where the result lives
- this is only temporary and will be removed again, once the move is fully completed
- send absolute URLs for Ghost posts and Markdown pages to Algolia
- convert the URL in search results again if it lives on the current site