### PR TITLE
Fix link to GA

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -107,7 +107,7 @@ const HomePage = ({ data, location }) => {
                                 <img className="w10 mb1" src="https://res.cloudinary.com/tryghost/image/fetch/w_120,h_100,c_fit/https://docs.ghost.io/content/images/2018/09/unsplash.svg" alt="Unsplash" />
                                 Unsplash
                             </Box>
-                            <Box to="/integrations/google-analytics/" className="flex flex-column justify-between items-center middarkgrey pa2 pt5 pb5 tdn tc" elevation="2" radius="4">
+                            <Box to="/integrations/google/" className="flex flex-column justify-between items-center middarkgrey pa2 pt5 pb5 tdn tc" elevation="2" radius="4">
                                 <img className="w10 mb1" src="https://res.cloudinary.com/tryghost/image/fetch/w_120,h_100,c_fit/https://docs.ghost.io/content/images/2018/09/google-analytics-1.png" alt="Google Analytics" />
                                 Google Analytics
                             </Box>


### PR DESCRIPTION
This fixes a broken link to the Google Analytics page I was seeing in Firefox and Chrome mobile.

I see there is a redirection file for Netlify but that only seems to work when you refresh the 404 page.