### PR TITLE
Fixed grammatical errors

### DIFF
--- a/content/concepts/admin.md
+++ b/content/concepts/admin.md
@@ -26,7 +26,7 @@ Great for editors. Great for developers. Also available as [Desktop App](https:/
 
 ## Publishing workflow
 
-Hacking together some Markdown files and throwing a static-site generator on top is nice in theory, but anyone who has tried to manage a content archive knows how quickly this falls apart under even light usage. What happens when you want to schedule a post to be published on Monday?
+Hacking together some Markdown files and throwing a static-site generator on top is nice in theory, but anyone who has tried to manage a content archive knows how quickly this falls apart even under light usage. What happens when you want to schedule a post to be published on Monday?
 
 ![Publishing Worfklow](../images/concepts/publishing-workflow.png)
 
@@ -39,6 +39,6 @@ Ghost Admin also comes with a world-class editor for authoring posts, which is d
 
 ![Ghost Editor](../images/concepts/ghost-admin-editor.png)
 
-But, our default client app isn't the only way to interact write content to the Ghost [Admin API](/api/admin/). You can send data into Ghost from pretty much anywhere, or even write your own custom admin client if you have a particular usecase which requires it.
+But, our default client app isn't the only way to interact with content on the Ghost [Admin API](/api/admin/). You can send data into Ghost from pretty much anywhere, or even write your own custom admin client if you have a particular usecase which requires it.
 
 Ghost-Admin is extremely powerful but entirely optional.


### PR DESCRIPTION
I was going through the documentation and found some phrases which got me confused for a few seconds until I rephrased them in my head.

In the "Publishing workflow" section in /content/admin:
"how quickly this falls apart **under even** light usage" can be changed to "how quickly this falls apart **even under** light usage"

In the "Best-in-class editor" section in /content/admin:
"But, our default client app isn't the only way to **interact write content to** the Ghost Admin API" can be changed to "But, our default client app isn't the only way to **interact with content on** the Ghost Admin API"

I think these changes make for better reading.
