### PR TITLE
Add new Gatsby documentation sidebar structure

### DIFF
--- a/src/data/sidebars/gatsby.yaml
+++ b/src/data/sidebars/gatsby.yaml
@@ -1,4 +1,17 @@
-- title: Gatsby
-  items:
-    - title: Overview
-      link: /api/gatsby/
+- groups:
+  - group: Working With Gatsby
+    items:
+      - title: Overview
+        link: /api/gatsby/
+  - group: GraphQL, Gatsby & Ghost API
+    items:
+      - title: Getting Started
+        link: /api/gatsby/graphql-gatsby-ghost-api/
+  - group: Use-Cases & Pitfalls
+    items:
+      - title: Overview
+        link: /api/gatsby/use-cases-pitfalls/
+  - group: GraphQL Recipes
+    items:
+      - title: Recipes
+        link: /api/gatsby/graphql-recipes-for-ghost


### PR DESCRIPTION
Add new sidebar structure to match with content added in TryGhost/docs-api#59, the new Gatsby documentation.