### PR TITLE
Better explain image compression

### DIFF
--- a/content/concepts/config.md
+++ b/content/concepts/config.md
@@ -475,7 +475,7 @@ When uploading images into the Ghost editor, they are automatically processed an
 Image compression details:
 
 * Resize the image to 2000px max width
-* JPEG's are compressed to 80% quality.
+* JPEG's are compressed to 20% of the original quality. If you upload a 100kb JPEG file it will be compressed to around 20kb
 * Meta data removed
 
 The original image is kept with the suffix `_o`.


### PR DESCRIPTION
I think the 80% quality image optimization explanation is ambiguos. Clarification needs to be made. Does the image is compressed 80% (100kb x .2 = 20kb)  or does the uploaded image will have 80% of the original quality?  (100kb x .8 = 80kb).

Please include a detailed description of your changes and provide before/after screenshots if applicable
