### PR TITLE
Correct contradicting information and fix typo in config.md

### DIFF
--- a/content/concepts/config.md
+++ b/content/concepts/config.md
@@ -70,7 +70,7 @@ There are a number of configuration options which are explained in detail in thi
 | Name      | Required?     | Description |
 | --------- | ------------- | ----------- |
 | `url`     | In production | Set the public URL for your blog |
-| `database` | In production | Type of databased used (default: sqlite3) |
+| `database` | In production | Type of database used (default: MySQL) |
 | `mail`    | In production | Add a mail service |
 | `admin`   | Optional      | Set the protocol and hostname for your admin panel |
 | `server`   | Optional | Host and port, or socket for Ghost to listen on |


### PR DESCRIPTION
Line 73 and Line 110 appear to contradict themselves - I've changed line 73 to be consistent with 110 (production default is MySQL, with a second alternative of sqlite3). Also fixed a little typo.