### PR TITLE
Fixed broken link to supported node versions for Ubuntu

### DIFF
--- a/content/install/ubuntu.md
+++ b/content/install/ubuntu.md
@@ -133,7 +133,7 @@ su - <user>
 
 ### Install Node.js
 
-You will need to have a [supported version](/faq/node-versions/) of Node installed system-wide in the manner described below. If you have a different setup, you may encounter problems.
+You will need to have a [supported version](https://docs.ghost.org/faq/node-versions/) of Node installed system-wide in the manner described below. If you have a different setup, you may encounter problems.
 
 ```bash
 # Add the NodeSource APT repository for Node 10

--- a/content/install/ubuntu.md
+++ b/content/install/ubuntu.md
@@ -133,7 +133,7 @@ su - <user>
 
 ### Install Node.js
 
-You will need to have a [supported version](https://docs.ghost.org/faq/node-versions/) of Node installed system-wide in the manner described below. If you have a different setup, you may encounter problems.
+You will need to have a [supported version](https://ghost.org/faq/node-versions/) of Node installed system-wide in the manner described below. If you have a different setup, you may encounter problems.
 
 ```bash
 # Add the NodeSource APT repository for Node 10


### PR DESCRIPTION
Fixed broken link to supported node versions

On the Ubuntu Installation Guide under Server Setup I noticed the link to supported versions of Node was broken. This should fix that.

URL: [https://docs.ghost.org/install/ubuntu/#install-nodejs](https://docs.ghost.org/install/ubuntu/#install-nodejs)
